### PR TITLE
feat: migrate to async IPC with new `qtile-cmd-client` API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -114,7 +114,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -454,7 +454,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -604,16 +604,7 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys 0.4.1",
-]
-
-[[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
-dependencies = [
- "dirs-sys 0.5.0",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -624,20 +615,8 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.4.6",
+ "redox_users",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users 0.5.2",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -961,7 +940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1108,7 +1087,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95f87364ea709292a3b3f74014ce3ee78412c89807eea75a358c8e029b000994"
 dependencies = [
- "dirs 5.0.1",
+ "dirs",
  "ini_core",
  "once_cell",
  "thiserror 1.0.69",
@@ -2498,7 +2477,7 @@ dependencies = [
 [[package]]
 name = "qtile-cmd-client"
 version = "0.1.1"
-source = "git+https://github.com/ervinpopescu/qtile-cmd-client#aca09721cc7dc4b2dd9a103b5bbad43f2228eeb8"
+source = "git+https://github.com/ervinpopescu/qtile-cmd-client?branch=feature%2Fjson-ipc#b308d43bdd25c442968a6d96fe40c0c657e2a488"
 dependencies = [
  "anyhow",
  "clap",
@@ -2612,17 +2591,6 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2744,7 +2712,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2911,7 +2879,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
  "bstr",
- "dirs 6.0.0",
+ "dirs",
  "os_str_bytes",
 ]
 
@@ -3093,7 +3061,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3983,7 +3951,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -114,7 +114,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -454,7 +454,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -604,16 +604,7 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys 0.4.1",
-]
-
-[[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
-dependencies = [
- "dirs-sys 0.5.0",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -624,20 +615,8 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.4.6",
+ "redox_users",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users 0.5.2",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -961,7 +940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1108,7 +1087,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95f87364ea709292a3b3f74014ce3ee78412c89807eea75a358c8e029b000994"
 dependencies = [
- "dirs 5.0.1",
+ "dirs",
  "ini_core",
  "once_cell",
  "thiserror 1.0.69",
@@ -2509,7 +2488,7 @@ dependencies = [
 [[package]]
 name = "qtile-cmd-client"
 version = "0.1.1"
-source = "git+https://github.com/ervinpopescu/qtile-cmd-client#aca09721cc7dc4b2dd9a103b5bbad43f2228eeb8"
+source = "git+https://github.com/ervinpopescu/qtile-cmd-client?branch=feature%2Fjson-ipc#b308d43bdd25c442968a6d96fe40c0c657e2a488"
 dependencies = [
  "anyhow",
  "clap",
@@ -2623,17 +2602,6 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2755,7 +2723,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2922,7 +2890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
  "bstr",
- "dirs 6.0.0",
+ "dirs",
  "os_str_bytes",
 ]
 
@@ -3104,7 +3072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3995,7 +3963,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ eframe = { version = "0.34.1", default-features = false, features = [
 freedesktop-icons = { version = "0.4" }
 indexmap = { version = "2.14", features = ["serde"] }
 log = { version = "0.4" }
-qtile-cmd-client = { git = "https://github.com/ervinpopescu/qtile-cmd-client" }
+qtile-cmd-client = { git = "https://github.com/ervinpopescu/qtile-cmd-client", branch = "feature/json-ipc" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 simple_logger = { version = "5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ eframe = { version = "0.34.3", default-features = false, features = [
 freedesktop-icons = { version = "0.4" }
 indexmap = { version = "2.14", features = ["serde"] }
 log = { version = "0.4" }
-qtile-cmd-client = { git = "https://github.com/ervinpopescu/qtile-cmd-client" }
+qtile-cmd-client = { git = "https://github.com/ervinpopescu/qtile-cmd-client", branch = "feature/json-ipc" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 simple_logger = { version = "5" }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -323,4 +323,24 @@ mod tests {
         let e = err(r#"[1,2,3]"#);
         assert!(e.contains("message_type"), "got: {e}");
     }
+
+    #[test]
+    fn get_socket_path_custom_path_returned_unchanged() {
+        let p = Path::new("/tmp/qalttab_unit_test.sock");
+        assert_eq!(
+            get_socket_path(Some(p)),
+            PathBuf::from("/tmp/qalttab_unit_test.sock")
+        );
+    }
+
+    #[test]
+    fn get_socket_path_default_contains_expected_segments() {
+        let path = get_socket_path(None);
+        let s = path.to_str().unwrap();
+        assert!(s.contains("qtile"), "expected 'qtile' in default path: {s}");
+        assert!(
+            s.contains("qalttab."),
+            "expected 'qalttab.' in default path: {s}"
+        );
+    }
 }

--- a/src/qaltd.rs
+++ b/src/qaltd.rs
@@ -68,4 +68,26 @@ mod tests {
     fn empty_line_is_not_an_alt_release() {
         assert!(!is_alt_release_event(""));
     }
+
+    #[test]
+    fn right_alt_pressed_is_not_an_alt_release() {
+        assert!(!is_alt_release_event(
+            "event5  KEYBOARD_KEY  +0.001s  KEY_RIGHTALT (100) pressed"
+        ));
+    }
+
+    #[test]
+    fn released_keyword_alone_without_alt_is_not_detected() {
+        assert!(!is_alt_release_event("released"));
+    }
+
+    #[test]
+    fn alt_keyword_alone_without_released_is_not_detected() {
+        assert!(!is_alt_release_event("KEY_LEFTALT"));
+    }
+
+    #[test]
+    fn both_alt_keys_mentioned_with_released_detects_either() {
+        assert!(is_alt_release_event("KEY_LEFTALT KEY_RIGHTALT released"));
+    }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -11,7 +11,7 @@ use egui::{
     Vec2,
 };
 use freedesktop_icons::lookup;
-use qtile_client_lib::utils::client::{CallResult, InteractiveCommandClient};
+use qtile_client_lib::utils::client::{CommandQuery, QtileClient};
 use serde_json::Value;
 use sysinfo::{Pid, System};
 use tokio::sync::mpsc::unbounded_channel;
@@ -33,7 +33,7 @@ pub trait QtileClientTrait: Send + Sync {
     ) -> anyhow::Result<serde_json::Value>;
 }
 
-/// Production implementation using `InteractiveCommandClient` from qtile-cmd-client main.
+/// Production implementation using `QtileClient` + `CommandQuery` from the json-ipc API.
 pub struct IccQtileClient;
 
 impl QtileClientTrait for IccQtileClient {
@@ -43,10 +43,17 @@ impl QtileClientTrait for IccQtileClient {
         function: Option<String>,
         args: Option<Vec<String>>,
     ) -> anyhow::Result<serde_json::Value> {
-        match InteractiveCommandClient::call(object, function, args, false)? {
-            CallResult::Value(v) => Ok(v),
-            CallResult::Text(t) => Ok(serde_json::Value::String(t)),
+        let mut query = CommandQuery::new();
+        if let Some(obj) = object {
+            query = query.object(obj);
         }
+        if let Some(func) = function {
+            query = query.function(func);
+        }
+        if let Some(a) = args {
+            query = query.args(a);
+        }
+        QtileClient::new(false).call(query).map(|r| r.to_json())
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -936,4 +936,109 @@ mod tests {
         assert_eq!(s.focus_index, 0);
         assert!(s.current_focus_history.is_none());
     }
+
+    #[test]
+    fn shared_state_fields_can_be_mutated() {
+        let s = SharedState {
+            is_visible: true,
+            focus_index: 5,
+            last_width: 300,
+            last_height: 400,
+            last_placed_height: 400.0,
+            cached_wid: Some("42".to_string()),
+            ..SharedState::default()
+        };
+        assert!(s.is_visible);
+        assert_eq!(s.focus_index, 5);
+        assert_eq!(s.last_width, 300);
+        assert_eq!(s.last_height, 400);
+        assert!((s.last_placed_height - 400.0).abs() < f32::EPSILON);
+        assert_eq!(s.cached_wid, Some("42".to_string()));
+    }
+
+    #[test]
+    fn message_type_none_is_distinct_from_other_variants() {
+        assert_ne!(MessageType::None, MessageType::ClientFocus);
+        assert_ne!(MessageType::None, MessageType::CycleWindows);
+    }
+
+    #[test]
+    fn message_type_clone_preserves_variant() {
+        assert_eq!(MessageType::None.clone(), MessageType::None);
+        assert_eq!(MessageType::ClientFocus.clone(), MessageType::ClientFocus);
+        assert_eq!(MessageType::CycleWindows.clone(), MessageType::CycleWindows);
+    }
+
+    #[test]
+    fn response_clone_equals_original() {
+        let r = Response {
+            message_type: MessageType::CycleWindows,
+            windows: vec![],
+            focus_index: Some(2),
+        };
+        assert_eq!(r.clone(), r);
+    }
+
+    #[test]
+    fn response_with_windows_clone_equals_original() {
+        let mut win = std::collections::HashMap::new();
+        win.insert("id".to_string(), "7".to_string());
+        win.insert("name".to_string(), "Term".to_string());
+        let r = Response {
+            message_type: MessageType::ClientFocus,
+            windows: vec![win],
+            focus_index: None,
+        };
+        assert_eq!(r.clone(), r);
+    }
+
+    #[test]
+    fn app_event_alt_released_debug_contains_variant_name() {
+        let s = format!("{:?}", AppEvent::AltReleased);
+        assert!(s.contains("AltReleased"), "got: {s}");
+    }
+
+    #[test]
+    fn app_event_our_window_id_carries_payload() {
+        let e = AppEvent::OurWindowId("wid_99".to_string());
+        if let AppEvent::OurWindowId(id) = e {
+            assert_eq!(id, "wid_99");
+        } else {
+            panic!("unexpected variant");
+        }
+    }
+
+    #[test]
+    fn app_event_unix_socket_msg_carries_response() {
+        let r = Response {
+            message_type: MessageType::CycleWindows,
+            windows: vec![],
+            focus_index: Some(0),
+        };
+        let e = AppEvent::UnixSocketMsg(r.clone());
+        if let AppEvent::UnixSocketMsg(inner) = e {
+            assert_eq!(inner, r);
+        } else {
+            panic!("unexpected variant");
+        }
+    }
+
+    #[test]
+    fn truncate_empty_string_unchanged() {
+        assert_eq!(truncate_window_name("", 31), "");
+    }
+
+    #[test]
+    fn truncate_single_char_limit() {
+        assert_eq!(truncate_window_name("hello", 1), "h");
+    }
+
+    #[test]
+    fn truncate_mixed_ascii_and_unicode() {
+        let name = "ab😀cd";
+        // 5 chars total: a, b, 😀, c, d — truncating to 3 keeps "ab😀"
+        let result = truncate_window_name(name, 3);
+        assert_eq!(result.chars().count(), 3);
+        assert_eq!(result, "ab😀");
+    }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1041,4 +1041,87 @@ mod tests {
         assert_eq!(result.chars().count(), 3);
         assert_eq!(result, "ab😀");
     }
+
+    // ── IccQtileClient::call coverage ─────────────────────────────────────────
+    // Serialize env-var mutations so parallel tests don't interfere.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn restore_env(orig_cache: Option<String>, orig_display: Option<String>) {
+        // SAFETY: ENV_LOCK is held by every caller, serialising all env mutations.
+        unsafe {
+            match orig_cache {
+                Some(v) => std::env::set_var("XDG_CACHE_HOME", v),
+                None => std::env::remove_var("XDG_CACHE_HOME"),
+            }
+            match orig_display {
+                Some(v) => std::env::set_var("WAYLAND_DISPLAY", v),
+                None => std::env::remove_var("WAYLAND_DISPLAY"),
+            }
+        }
+    }
+
+    /// All-`Some` arms + success path: spins up a mock Qtile socket that returns
+    /// a legacy `[0, null]` response, exercising every new line in
+    /// `IccQtileClient::call` including the `.map(|r| r.to_json())` closure.
+    #[test]
+    fn icc_qtile_client_call_all_some_branches_via_mock_socket() {
+        use std::io::{Read, Write};
+        use std::os::unix::net::UnixListener;
+
+        const SOCKET_DIR: &str = "/tmp/qalttab_icc_mock_test";
+        const DISPLAY: &str = "wayland-qalttab-mock";
+        let socket_path = format!("{SOCKET_DIR}/qtile/qtilesocket.{DISPLAY}");
+
+        std::fs::create_dir_all(format!("{SOCKET_DIR}/qtile")).unwrap();
+        let _ = std::fs::remove_file(&socket_path);
+
+        let listener = UnixListener::bind(&socket_path).unwrap();
+        let server = std::thread::spawn(move || {
+            if let Ok((mut conn, _)) = listener.accept() {
+                let mut buf = String::new();
+                let _ = conn.read_to_string(&mut buf);
+                // Minimal valid Qtile legacy response: [status, result]
+                let _ = conn.write_all(b"[0, null]");
+            }
+        });
+
+        let _guard = ENV_LOCK.lock().unwrap();
+        let orig_cache = std::env::var("XDG_CACHE_HOME").ok();
+        let orig_display = std::env::var("WAYLAND_DISPLAY").ok();
+        // SAFETY: ENV_LOCK serialises all env mutations in this test module.
+        unsafe {
+            std::env::set_var("XDG_CACHE_HOME", SOCKET_DIR);
+            std::env::set_var("WAYLAND_DISPLAY", DISPLAY);
+        }
+
+        let result = IccQtileClient.call(
+            Some(vec![]),
+            Some("eval".to_string()),
+            Some(vec!["1+1".to_string()]),
+        );
+
+        restore_env(orig_cache, orig_display);
+        let _ = server.join();
+
+        assert_eq!(result.unwrap(), serde_json::Value::Null);
+    }
+
+    /// `None` arms for `object` and `args`: verifies those branches are skipped,
+    /// and that the function returns `Err` when no socket exists at the path.
+    #[test]
+    fn icc_qtile_client_call_none_object_and_args_returns_err() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let orig_cache = std::env::var("XDG_CACHE_HOME").ok();
+        let orig_display = std::env::var("WAYLAND_DISPLAY").ok();
+        // SAFETY: ENV_LOCK serialises all env mutations in this test module.
+        unsafe {
+            std::env::set_var("XDG_CACHE_HOME", "/tmp/qalttab_no_qtile_socket_xyz");
+            std::env::set_var("WAYLAND_DISPLAY", "wayland-qalttab-no-socket");
+        }
+
+        let result = IccQtileClient.call(None, Some("eval".to_string()), None);
+
+        restore_env(orig_cache, orig_display);
+        assert!(result.is_err());
+    }
 }

--- a/tests/ipc_server.rs
+++ b/tests/ipc_server.rs
@@ -1,5 +1,5 @@
-use qalttab::ipc::listen;
-use qalttab::ui::AppEvent;
+use qalttab::ipc::{handle_conn, listen};
+use qalttab::ui::{AppEvent, MessageType};
 use serde_json::json;
 use std::path::Path;
 use std::time::Duration;
@@ -87,4 +87,106 @@ async fn server_handles_sequential_messages() {
             .expect("timed out waiting for event");
         assert!(matches!(event, Some(AppEvent::UnixSocketMsg(_))));
     }
+}
+
+// ── handle_conn unit-level tests using an in-process socket pair ──────────────
+
+#[tokio::test]
+async fn handle_conn_zero_bytes_returns_ok() {
+    let (client, server) = tokio::net::UnixStream::pair().unwrap();
+    drop(client); // EOF immediately → 0 bytes read
+    let (tx, _rx) = mpsc::unbounded_channel::<AppEvent>();
+    let ctx = egui::Context::default();
+    assert!(handle_conn(server, tx, ctx).await.is_ok());
+}
+
+#[tokio::test]
+async fn handle_conn_invalid_json_returns_error() {
+    let (mut client, server) = tokio::net::UnixStream::pair().unwrap();
+    let (tx, _rx) = mpsc::unbounded_channel::<AppEvent>();
+    let ctx = egui::Context::default();
+    client.write_all(b"not json at all").await.unwrap();
+    drop(client);
+    assert!(handle_conn(server, tx, ctx).await.is_err());
+}
+
+#[tokio::test]
+async fn handle_conn_valid_cycle_windows_sends_event_and_replies_success() {
+    let (mut client, server) = tokio::net::UnixStream::pair().unwrap();
+    let (tx, mut rx) = mpsc::unbounded_channel::<AppEvent>();
+    let ctx = egui::Context::default();
+
+    let payload = json!({
+        "message_type": "cycle_windows",
+        "windows": [{"id": "1", "name": "Term", "class": "alacritty", "group_name": "coding", "group_label": ""}],
+        "focus_index": 0
+    });
+    client
+        .write_all(&serde_json::to_vec(&payload).unwrap())
+        .await
+        .unwrap();
+    client.shutdown().await.unwrap(); // signal EOF after the payload
+
+    assert!(handle_conn(server, tx, ctx).await.is_ok());
+
+    // Server must have written {"message":"success"} back to the client half
+    let mut buf = [0u8; 256];
+    let n = client.read(&mut buf).await.unwrap();
+    let reply: serde_json::Value = serde_json::from_slice(&buf[..n]).unwrap();
+    assert_eq!(reply["message"], "success");
+
+    // And the event must have been placed on the channel
+    let event = rx.try_recv().expect("event should be present");
+    if let AppEvent::UnixSocketMsg(r) = event {
+        assert_eq!(r.message_type, MessageType::CycleWindows);
+        assert_eq!(r.focus_index, Some(0));
+        assert_eq!(r.windows.len(), 1);
+        assert_eq!(r.windows[0]["class"], "alacritty");
+    } else {
+        panic!("expected UnixSocketMsg, got {:?}", event);
+    }
+}
+
+#[tokio::test]
+async fn handle_conn_valid_client_focus_sends_event() {
+    let (mut client, server) = tokio::net::UnixStream::pair().unwrap();
+    let (tx, mut rx) = mpsc::unbounded_channel::<AppEvent>();
+    let ctx = egui::Context::default();
+
+    let payload = json!({
+        "message_type": "client_focus",
+        "windows": [{"id": "5", "name": "Browser"}]
+    });
+    client
+        .write_all(&serde_json::to_vec(&payload).unwrap())
+        .await
+        .unwrap();
+    client.shutdown().await.unwrap();
+
+    assert!(handle_conn(server, tx, ctx).await.is_ok());
+
+    let event = rx.try_recv().expect("event should be present");
+    if let AppEvent::UnixSocketMsg(r) = event {
+        assert_eq!(r.message_type, MessageType::ClientFocus);
+        assert_eq!(r.focus_index, None);
+        assert_eq!(r.windows[0]["id"], "5");
+    } else {
+        panic!("expected UnixSocketMsg, got {:?}", event);
+    }
+}
+
+#[tokio::test]
+async fn handle_conn_unknown_message_type_returns_error() {
+    let (mut client, server) = tokio::net::UnixStream::pair().unwrap();
+    let (tx, _rx) = mpsc::unbounded_channel::<AppEvent>();
+    let ctx = egui::Context::default();
+
+    let payload = json!({ "message_type": "totally_unknown", "windows": [] });
+    client
+        .write_all(&serde_json::to_vec(&payload).unwrap())
+        .await
+        .unwrap();
+    drop(client);
+
+    assert!(handle_conn(server, tx, ctx).await.is_err());
 }


### PR DESCRIPTION
## Summary

- Adds 2 new unit tests for `IccQtileClient::call` to bring patch coverage off zero
- Mock socket test (`icc_qtile_client_call_all_some_branches_via_mock_socket`): spins up a `UnixListener` in a thread, redirects `XDG_CACHE_HOME`/`WAYLAND_DISPLAY` to it, exercises all three `Some` branches and the `.map(|r| r.to_json())` closure with a `[0, null]` legacy response
- No-socket test (`icc_qtile_client_call_none_object_and_args_returns_err`): exercises `None` branches for `object` and `args` by pointing env vars at a nonexistent path, asserts `Err`
- `ENV_LOCK` (`Mutex<()>`) serialises env-var mutations; `set_var`/`remove_var` wrapped in `unsafe` blocks (required by Rust edition 2024)

## Test plan

- [ ] `cargo test` — all 98 tests pass
- [ ] `icc_qtile_client_call_all_some_branches_via_mock_socket` passes without a running Qtile session
- [ ] `icc_qtile_client_call_none_object_and_args_returns_err` passes without a running Qtile session
- [ ] Patch coverage for `IccQtileClient::call` is no longer 0%