### PR TITLE
ci: bump GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install system dependencies
         run: |
@@ -45,7 +45,7 @@ jobs:
           tool: cargo-tarpaulin
 
       - name: Cache Cargo registry and build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -68,7 +68,7 @@ jobs:
         run: cargo tarpaulin --lib --out xml --output-dir coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           files: coverage/cobertura.xml
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary

- `actions/checkout@v4` → `v6`
- `actions/cache@v4` → `v5`
- `codecov/codecov-action@v4` → `v6`

## Why

GitHub is removing Node.js 20 from Actions runners on September 16, 2026 (forced to Node.js 24 starting June 2, 2026). The old v4 releases of these actions use Node.js 20 and will break. This bumps all three to their current latest major versions which support Node.js 24.